### PR TITLE
feat: add Elasticsearch index and sample ingestion script (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,19 @@ Small demo showing Elasticsearch full-text search with a minimal FastAPI backend
 1. `docker compose up -d`
 2. `cd backend && docker build -t movie-backend . && docker run --rm -p 8000:8000 movie-backend`
 
+## 🧩 Ingest Sample Data
+
+To load a small movie dataset into Elasticsearch:
+
+```bash
+docker compose up -d
+python scripts/ingest_sample.py
+```
+Then verify
+
+```bash
+curl -s http://localhost:9200/movies/_count
+```
+You should see a count of 5 documents.
+
 (Full instructions to be added in later steps)

--- a/data/sample_movies.json
+++ b/data/sample_movies.json
@@ -1,0 +1,37 @@
+[
+  {
+    "title": "Inception",
+    "overview": "A thief who steals corporate secrets through dream-sharing technology is given a task of planting an idea.",
+    "genre": "Sci-Fi",
+    "release_date": "2010-07-16",
+    "rating": 8.8
+  },
+  {
+    "title": "The Dark Knight",
+    "overview": "Batman faces the Joker, a criminal mastermind who wants to plunge Gotham into anarchy.",
+    "genre": "Action",
+    "release_date": "2008-07-18",
+    "rating": 9.0
+  },
+  {
+    "title": "Interstellar",
+    "overview": "A team travels through a wormhole in search of a new home for humanity.",
+    "genre": "Adventure",
+    "release_date": "2014-11-07",
+    "rating": 8.6
+  },
+  {
+    "title": "The Matrix",
+    "overview": "A hacker discovers the reality he lives in is a simulated world controlled by machines.",
+    "genre": "Sci-Fi",
+    "release_date": "1999-03-31",
+    "rating": 8.7
+  },
+  {
+    "title": "Gladiator",
+    "overview": "A Roman general seeks revenge against the corrupt emperor who murdered his family.",
+    "genre": "Drama",
+    "release_date": "2000-05-05",
+    "rating": 8.5
+  }
+]

--- a/mappings/movies_mapping.json
+++ b/mappings/movies_mapping.json
@@ -1,0 +1,11 @@
+{
+  "mappings": {
+    "properties": {
+      "title": { "type": "text" },
+      "overview": { "type": "text" },
+      "genre": { "type": "keyword" },
+      "release_date": { "type": "date" },
+      "rating": { "type": "float" }
+    }
+  }
+}

--- a/scripts/ingest_sample.py
+++ b/scripts/ingest_sample.py
@@ -1,0 +1,34 @@
+import json
+import os
+from elasticsearch import Elasticsearch, helpers
+
+ES_URL = os.getenv("ELASTICSEARCH_URL", "http://localhost:9200")
+INDEX_NAME = "movies"
+
+def create_index(es_client):
+    with open("mappings/movies_mapping.json", "r") as f:
+        mapping = json.load(f)
+    if not es_client.indices.exists(index=INDEX_NAME):
+        es_client.indices.create(index=INDEX_NAME, body=mapping)
+        print(f"✅ Created index: {INDEX_NAME}")
+    else:
+        print(f"ℹ️ Index '{INDEX_NAME}' already exists")
+
+def ingest_data(es_client):
+    with open("data/sample_movies.json", "r") as f:
+        docs = json.load(f)
+    actions = [
+        {"_index": INDEX_NAME, "_source": doc}
+        for doc in docs
+    ]
+    helpers.bulk(es_client, actions)
+    print(f"✅ Indexed {len(docs)} movie documents")
+
+if __name__ == "__main__":
+    es = Elasticsearch(ES_URL)
+    if not es.ping():
+        print("❌ Could not connect to Elasticsearch at", ES_URL)
+    else:
+        print("✅ Connected to Elasticsearch")
+        create_index(es)
+        ingest_data(es)


### PR DESCRIPTION
### 📄 Description
Added mapping definition, sample movie dataset, and ingestion script for creating and populating the `movies` index in Elasticsearch.

## Related issue
Closes #12 

## How to test
1. Run `docker compose up -d`
2. Run `python scripts/ingest_sample.py`
3. Verify:
   - `curl -s http://localhost:9200/movies/_count` → returns count = 5
   - `curl -s http://localhost:9200/movies/_search?q=Inception` → shows result

## Checklist
- [x] Mapping file added
- [x] Sample dataset added
- [x] Ingestion script added
- [x] README updated
- [x] Verified locally
