### PR TITLE
chore: add pytest setup and initial health check test (#18)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,8 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Query
 from pydantic import BaseModel
 from fastapi.responses import JSONResponse
 import os
+from app.models import SearchResponse
 
 app = FastAPI(title="Movie Search - Mini")
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "movie-search-app"
+version = "0.1.0"
+authors = [
+  { name = "Hemanth0411", email = "" },
+]
+description = "Movie search application backend"
+readme = "README.md"
+requires-python = ">=3.11"
+
+[tool.pytest.ini_options]
+pythonpath = "."
+testpaths = ["tests"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,6 @@
 fastapi
 uvicorn[standard]
 elasticsearch==8.9.0
+pytest
+httpx
+

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Add the parent directory to PYTHONPATH
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_health_check():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
**Linked Issue:** #18 

**Summary:**
This PR introduces automated testing support using pytest.  
It includes a base test for the `/health` endpoint and makes it possible to run tests both locally and in Docker.

**Changes:**
- Added `pytest` and `httpx` to `requirements.txt`
- Created `tests/test_health.py`
- Verified that `docker compose run --rm backend pytest` runs successfully

**Testing:**
```bash
docker compose run --rm backend pytest -v
```
Result -> ` 1 passed `