### PR TITLE
ci: add CD workflow to build and push Docker image to Docker Hub (#26)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,30 @@
+name: CD - Push Docker Image to Docker Hub
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/movie-search-app-backend:latest


### PR DESCRIPTION
Closes #26

**Description:**
This PR adds an automated workflow that builds the backend Docker image and pushes it to Docker Hub whenever a new commit is pushed to the `main` branch.

**Changes Made:**
- Added `.github/workflows/cd.yml`
- Configured Docker login and build-push steps
- Uses repository secrets for credentials

**Verification:**
- On merge to `main`, Docker Hub should show the updated image:
  `${{ secrets.DOCKERHUB_USERNAME }}/movie-search-app-backend:latest`

**Type:** `ci/cd`
